### PR TITLE
Block attachment colour tweak

### DIFF
--- a/alerts.go
+++ b/alerts.go
@@ -105,16 +105,16 @@ func (alert Alert) PostMessage() (string, string, []slack.Block, error) {
 		alert.MessageBody = messageBlocks
 		attachment.Blocks.BlockSet = append(attachment.Blocks.BlockSet, messageBlocks...)
 
-		if severity == "warn" {
-			log.Print("Adding warning flag to message")
-			attachment.Color = "#d1ad1d"
-		}
-		if severity == "critical" {
-			log.Print("Adding danger flag to message")
-			attachment.Color = "#d11d1d"
-		}
-
 		if alert.MessageTS != "" {
+			if severity == "warn" {
+				log.Print("Adding warning flag to message")
+				attachment.Color = "#d1ad1d"
+			}
+			if severity == "critical" {
+				log.Print("Adding danger flag to message")
+				attachment.Color = "#d11d1d"
+			}
+			
 			options = append(options, slack.MsgOptionBroadcast())
 			log.Print("Adding broadcast flag to message")
 		}


### PR DESCRIPTION
Just ensures the initial alerts are correctly colour coded, updates and resolves should have a grey sidebar so the original alerts stand out. This PR fixes a bug implementing the above.