### PR TITLE
Promalert Slack alert colour bars

### DIFF
--- a/alerts.go
+++ b/alerts.go
@@ -106,15 +106,6 @@ func (alert Alert) PostMessage() (string, string, []slack.Block, error) {
 		attachment.Blocks.BlockSet = append(attachment.Blocks.BlockSet, messageBlocks...)
 
 		if alert.MessageTS != "" {
-			if severity == "warn" {
-				log.Print("Adding warning flag to message")
-				attachment.Color = "#d1ad1d"
-			}
-			if severity == "critical" {
-				log.Print("Adding danger flag to message")
-				attachment.Color = "#d11d1d"
-			}
-			
 			options = append(options, slack.MsgOptionBroadcast())
 			log.Print("Adding broadcast flag to message")
 		}
@@ -136,7 +127,7 @@ func (alert Alert) PostMessage() (string, string, []slack.Block, error) {
 
 		options = append(options, slack.MsgOptionBroadcast())
 		attachment.Blocks.BlockSet = append(attachment.Blocks.BlockSet, messageBlocks...)
-		attachment.Color = "#a6a6a6"
+		attachment.Color = "#36a64f"
 	}
 
 	if alert.MessageTS != "" {

--- a/alerts.go
+++ b/alerts.go
@@ -85,6 +85,15 @@ func (alert Alert) PostMessage() (string, string, []slack.Block, error) {
 	attachment := slack.Attachment{}
 	attachment.Blocks.BlockSet = make([]slack.Block, 0)
 
+	if severity == "warn" {
+		log.Print("Adding warning flag to message")
+		attachment.Color = "#d1ad1d"
+	}
+	if severity == "critical" {
+		log.Print("Adding danger flag to message")
+		attachment.Color = "#d11d1d"
+	}
+
 	if alert.Status == AlertStatusFiring || alert.MessageTS == "" {
 		log.Print("Composing full message")
 		images, err := alert.GeneratePictures()


### PR DESCRIPTION
Still experimenting with the Slack alert notification coloured bars. Here we make sure all types of message have coloured bars (if they are fires or refires) but if they are resolved the colour gets overridden green.