### PR TITLE
Slack alert message colour bar fixes

### DIFF
--- a/alerts.go
+++ b/alerts.go
@@ -84,7 +84,6 @@ func (alert Alert) PostMessage() (string, string, []slack.Block, error) {
 
 	attachment := slack.Attachment{}
 	attachment.Blocks.BlockSet = make([]slack.Block, 0)
-
 	switch severity {
 	case "warn":
 		attachment.Color = "#d1ad1d"

--- a/alerts.go
+++ b/alerts.go
@@ -86,11 +86,9 @@ func (alert Alert) PostMessage() (string, string, []slack.Block, error) {
 	attachment.Blocks.BlockSet = make([]slack.Block, 0)
 
 	if severity == "warn" {
-		log.Print("Adding warning flag to message")
 		attachment.Color = "#d1ad1d"
 	}
 	if severity == "critical" {
-		log.Print("Adding danger flag to message")
 		attachment.Color = "#d11d1d"
 	}
 
@@ -150,6 +148,12 @@ func (alert Alert) PostMessage() (string, string, []slack.Block, error) {
 
 		updateAttachment := slack.Attachment{}
 		updateAttachment.Blocks.BlockSet = append(alert.MessageBody, d...)
+		switch severity {
+		case "warn":
+			updateAttachment.Color = "#d1ad1d"
+		case "critical":
+			updateAttachment.Color = "#d11d1d"
+		}
 
 		respChannel, respTimestamp, err := SlackUpdateAlertMessage(
 			viper.GetString("slack_token"),

--- a/alerts.go
+++ b/alerts.go
@@ -85,10 +85,10 @@ func (alert Alert) PostMessage() (string, string, []slack.Block, error) {
 	attachment := slack.Attachment{}
 	attachment.Blocks.BlockSet = make([]slack.Block, 0)
 
-	if severity == "warn" {
+	switch severity {
+	case "warn":
 		attachment.Color = "#d1ad1d"
-	}
-	if severity == "critical" {
+	case "critical":
 		attachment.Color = "#d11d1d"
 	}
 

--- a/alerts.go
+++ b/alerts.go
@@ -143,19 +143,19 @@ func (alert Alert) PostMessage() (string, string, []slack.Block, error) {
 		log.Printf("MessageTS found, posting to thread: %s", alert.MessageTS)
 		options = append(options, slack.MsgOptionTS(alert.MessageTS))
 
-		updateBlocks := alert.MessageBody
 		d, err := ComposeUpdateFooter(alert, viper.GetString("footer_template"))
 		if err != nil {
 			return "", "", nil, err
 		}
 
-		updateBlocks = append(updateBlocks, d...)
+		updateAttachment := slack.Attachment{}
+		updateAttachment.Blocks.BlockSet = append(alert.MessageBody, d...)
 
 		respChannel, respTimestamp, err := SlackUpdateAlertMessage(
 			viper.GetString("slack_token"),
 			alert.Channel,
 			alert.MessageTS,
-			slack.MsgOptionBlocks(updateBlocks...),
+			slack.MsgOptionAttachments(updateAttachment),
 		)
 		if err != nil {
 			return "", "", nil, err

--- a/config.bugsnag.yaml
+++ b/config.bugsnag.yaml
@@ -13,7 +13,7 @@ header_template: |
   *Status:* {{if eq .Status "firing" }}:fire:{{else}}:white_check_mark::{{ end }}
 
 footer_template: |
-  {{if eq .Status "firing" }}:fire: Refired{{else}}:white_check_mark: Resolved{{ end }} {{ dateFormat "15:04:05" now }}
+  {{if eq .Status "firing" }}:fire: Refired{{else}}:white_check_mark: Resolved{{ end }} {{ dateFormat "15:04:05" (now) "UTC" }}
 
 message_template: |
   :chart_with_upwards_trend: *<{{ .GeneratorURL }}|Graph>*


### PR DESCRIPTION
This fixes an issue whereby Promalert would wipe out the coloured bars when updating Slack messages with a resolve time.