### PR TITLE
Pagerduty Slack message colours

### DIFF
--- a/alerts.go
+++ b/alerts.go
@@ -87,11 +87,11 @@ func (alert Alert) PostMessage() (string, string, []slack.Block, error) {
 	// palette: https://coolors.co/c200fb-ec0868-fc2f00-ec7d10-ffbc0a
 	switch severity {
 	case "warn":
-		attachment.Color = "#ffbc0a" // yellow
+		attachment.Color = "#ffa300" // yellow
 	case "critical":
-		attachment.Color = "#ec7d10" // orange
+		attachment.Color = "#ff5a60" // orange
 	case "page":
-		attachment.Color = "#fc2f00" // scarlet
+		attachment.Color = "#a15fff" // scarlet
 	}
 
 	if alert.Status == AlertStatusFiring || alert.MessageTS == "" {
@@ -136,7 +136,7 @@ func (alert Alert) PostMessage() (string, string, []slack.Block, error) {
 
 		options = append(options, slack.MsgOptionBroadcast())
 		attachment.Blocks.BlockSet = append(attachment.Blocks.BlockSet, messageBlocks...)
-		attachment.Color = "#36a64f"
+		attachment.Color = "#8cc63f"
 	}
 
 	if alert.MessageTS != "" {
@@ -152,11 +152,11 @@ func (alert Alert) PostMessage() (string, string, []slack.Block, error) {
 		updateAttachment.Blocks.BlockSet = append(alert.MessageBody, d...)
 		switch severity {
 		case "warn":
-			attachment.Color = "#ffbc0a" // yellow
+			attachment.Color = "#ffa300" // yellow
 		case "critical":
-			attachment.Color = "#ec7d10" // orange
+			attachment.Color = "#ff5a60" // orange
 		case "page":
-			attachment.Color = "#fc2f00" // scarlet
+			attachment.Color = "#a15fff" // scarlet
 		}
 
 		respChannel, respTimestamp, err := SlackUpdateAlertMessage(

--- a/alerts.go
+++ b/alerts.go
@@ -84,11 +84,14 @@ func (alert Alert) PostMessage() (string, string, []slack.Block, error) {
 
 	attachment := slack.Attachment{}
 	attachment.Blocks.BlockSet = make([]slack.Block, 0)
+	// palette: https://coolors.co/c200fb-ec0868-fc2f00-ec7d10-ffbc0a
 	switch severity {
 	case "warn":
-		attachment.Color = "#d1ad1d"
+		attachment.Color = "#ffbc0a" // yellow
 	case "critical":
-		attachment.Color = "#d11d1d"
+		attachment.Color = "#ec7d10" // orange
+	case "page":
+		attachment.Color = "#fc2f00" // scarlet
 	}
 
 	if alert.Status == AlertStatusFiring || alert.MessageTS == "" {
@@ -149,9 +152,11 @@ func (alert Alert) PostMessage() (string, string, []slack.Block, error) {
 		updateAttachment.Blocks.BlockSet = append(alert.MessageBody, d...)
 		switch severity {
 		case "warn":
-			updateAttachment.Color = "#d1ad1d"
+			attachment.Color = "#ffbc0a" // yellow
 		case "critical":
-			updateAttachment.Color = "#d11d1d"
+			attachment.Color = "#ec7d10" // orange
+		case "page":
+			attachment.Color = "#fc2f00" // scarlet
 		}
 
 		respChannel, respTimestamp, err := SlackUpdateAlertMessage(

--- a/alerts.go
+++ b/alerts.go
@@ -84,14 +84,14 @@ func (alert Alert) PostMessage() (string, string, []slack.Block, error) {
 
 	attachment := slack.Attachment{}
 	attachment.Blocks.BlockSet = make([]slack.Block, 0)
-	// palette: https://coolors.co/c200fb-ec0868-fc2f00-ec7d10-ffbc0a
+	// palette: https://bugsnag-component-library.netlify.app/?path=/docs/docs-colors--page
 	switch severity {
 	case "warn":
-		attachment.Color = "#ffa300" // yellow
+		attachment.Color = "#ffa300" // sunflower
 	case "critical":
-		attachment.Color = "#ff5a60" // orange
+		attachment.Color = "#ff5a60" // coral
 	case "page":
-		attachment.Color = "#a15fff" // scarlet
+		attachment.Color = "#a15fff" // orchid
 	}
 
 	if alert.Status == AlertStatusFiring || alert.MessageTS == "" {
@@ -152,11 +152,11 @@ func (alert Alert) PostMessage() (string, string, []slack.Block, error) {
 		updateAttachment.Blocks.BlockSet = append(alert.MessageBody, d...)
 		switch severity {
 		case "warn":
-			attachment.Color = "#ffa300" // yellow
+			attachment.Color = "#ffa300" // sunflower
 		case "critical":
-			attachment.Color = "#ff5a60" // orange
+			attachment.Color = "#ff5a60" // coral
 		case "page":
-			attachment.Color = "#a15fff" // scarlet
+			attachment.Color = "#a15fff" // orchid
 		}
 
 		respChannel, respTimestamp, err := SlackUpdateAlertMessage(

--- a/alerts.go
+++ b/alerts.go
@@ -136,7 +136,7 @@ func (alert Alert) PostMessage() (string, string, []slack.Block, error) {
 
 		options = append(options, slack.MsgOptionBroadcast())
 		attachment.Blocks.BlockSet = append(attachment.Blocks.BlockSet, messageBlocks...)
-		attachment.Color = "#8cc63f"
+		attachment.Color = "#8cc63f" // green
 	}
 
 	if alert.MessageTS != "" {


### PR DESCRIPTION
Switch promalert to colour message attachments in the Bugsnag palette.