### PR TITLE
Removed threaded message support

### DIFF
--- a/alerts.go
+++ b/alerts.go
@@ -120,6 +120,8 @@ func (alert Alert) PostMessage() (string, string, []slack.Block, error) {
 		}
 	} else {
 		log.Print("Composing short update message")
+		attachment.Color = "#8cc63f" // green
+
 		images, err := alert.GeneratePictures()
 		if err != nil {
 			return "", "", nil, err
@@ -136,33 +138,32 @@ func (alert Alert) PostMessage() (string, string, []slack.Block, error) {
 
 		options = append(options, slack.MsgOptionBroadcast())
 		attachment.Blocks.BlockSet = append(attachment.Blocks.BlockSet, messageBlocks...)
-		attachment.Color = "#8cc63f" // green
 	}
 
-	if alert.MessageTS != "" {
-		log.Printf("MessageTS found, posting to thread: %s", alert.MessageTS)
-		options = append(options, slack.MsgOptionTS(alert.MessageTS))
+	// if alert.MessageTS != "" {
+	// 	log.Printf("MessageTS found, posting to thread: %s", alert.MessageTS)
+	// 	options = append(options, slack.MsgOptionTS(alert.MessageTS))
 
-		d, err := ComposeUpdateFooter(alert, viper.GetString("footer_template"))
-		if err != nil {
-			return "", "", nil, err
-		}
+	// 	d, err := ComposeUpdateFooter(alert, viper.GetString("footer_template"))
+	// 	if err != nil {
+	// 		return "", "", nil, err
+	// 	}
 
-		updateAttachment := slack.Attachment{}
-		updateAttachment.Blocks.BlockSet = append(alert.MessageBody, d...)
+	// 	updateAttachment := slack.Attachment{}
+	// 	updateAttachment.Blocks.BlockSet = append(alert.MessageBody, d...)
 
-		respChannel, respTimestamp, err := SlackUpdateAlertMessage(
-			viper.GetString("slack_token"),
-			alert.Channel,
-			alert.MessageTS,
-			slack.MsgOptionAttachments(updateAttachment),
-		)
-		if err != nil {
-			return "", "", nil, err
-		}
+	// 	respChannel, respTimestamp, err := SlackUpdateAlertMessage(
+	// 		viper.GetString("slack_token"),
+	// 		alert.Channel,
+	// 		alert.MessageTS,
+	// 		slack.MsgOptionAttachments(updateAttachment),
+	// 	)
+	// 	if err != nil {
+	// 		return "", "", nil, err
+	// 	}
 
-		log.Printf("Slack message updated, channel: %s thread: %s", respChannel, respTimestamp)
-	}
+	// 	log.Printf("Slack message updated, channel: %s thread: %s", respChannel, respTimestamp)
+	// }
 
 	channel := viper.GetString("slack_channel")
 
@@ -180,7 +181,7 @@ func (alert Alert) PostMessage() (string, string, []slack.Block, error) {
 		return "", "", nil, err
 	}
 
-	log.Printf("Slack message sent, channel: %s thread: %s", respChannel, respTimestamp)
+	log.Printf("Slack message sent, channel: %s timestamp: %s", respChannel, respTimestamp)
 
 	return respChannel, respTimestamp, alert.MessageBody, nil
 }

--- a/alerts.go
+++ b/alerts.go
@@ -94,7 +94,7 @@ func (alert Alert) PostMessage() (string, string, []slack.Block, error) {
 		attachment.Color = "#a15fff" // orchid
 	}
 
-	if alert.Status == AlertStatusFiring || alert.MessageTS == "" {
+	if alert.Status == AlertStatusFiring {
 		log.Print("Composing full message")
 		images, err := alert.GeneratePictures()
 		if err != nil {

--- a/alerts.go
+++ b/alerts.go
@@ -140,31 +140,6 @@ func (alert Alert) PostMessage() (string, string, []slack.Block, error) {
 		attachment.Blocks.BlockSet = append(attachment.Blocks.BlockSet, messageBlocks...)
 	}
 
-	// if alert.MessageTS != "" {
-	// 	log.Printf("MessageTS found, posting to thread: %s", alert.MessageTS)
-	// 	options = append(options, slack.MsgOptionTS(alert.MessageTS))
-
-	// 	d, err := ComposeUpdateFooter(alert, viper.GetString("footer_template"))
-	// 	if err != nil {
-	// 		return "", "", nil, err
-	// 	}
-
-	// 	updateAttachment := slack.Attachment{}
-	// 	updateAttachment.Blocks.BlockSet = append(alert.MessageBody, d...)
-
-	// 	respChannel, respTimestamp, err := SlackUpdateAlertMessage(
-	// 		viper.GetString("slack_token"),
-	// 		alert.Channel,
-	// 		alert.MessageTS,
-	// 		slack.MsgOptionAttachments(updateAttachment),
-	// 	)
-	// 	if err != nil {
-	// 		return "", "", nil, err
-	// 	}
-
-	// 	log.Printf("Slack message updated, channel: %s thread: %s", respChannel, respTimestamp)
-	// }
-
 	channel := viper.GetString("slack_channel")
 
 	if alert.Channel != "" {

--- a/config.bugsnag.yaml
+++ b/config.bugsnag.yaml
@@ -11,9 +11,10 @@ metric_resolution: 100
 header_template: |
   *{{ .Labels.alertname }}*
   *Status:* {{if eq .Status "firing" }}:fire: Firing{{else}}:white_check_mark: Resolved{{ end }}
-
-footer_template: |
-  {{if eq .Status "firing" }}:fire: Refired{{else}}:white_check_mark: Resolved{{ end }} {{ dateFormat "15:04:05" (now) "UTC" }}
+  *Alert:* {{ if .Annotations.title }}{{ .Annotations.title }}{{ end }}{{ if .Annotations.summary }}{{ .Annotations.summary }}{{ end }}
+  
+# footer_template: |
+#   {{if eq .Status "firing" }}:fire: Refired{{else}}:white_check_mark: Resolved{{ end }} {{ dateFormat "15:04:05" (now) "UTC" }}
 
 message_template: |
   :chart_with_upwards_trend: *<{{ .GeneratorURL }}|Graph>*

--- a/config.bugsnag.yaml
+++ b/config.bugsnag.yaml
@@ -11,17 +11,14 @@ metric_resolution: 100
 header_template: |
   *{{ .Labels.alertname }}*
   *Status:* {{if eq .Status "firing" }}:fire: Firing{{else}}:white_check_mark: Resolved{{ end }}
+  {{ if .Labels.severity }}*Severity:*  `{{ .Labels.severity }}`{{ end }}
   *Alert:* {{ if .Annotations.title }}{{ .Annotations.title }}{{ end }}{{ if .Annotations.summary }}{{ .Annotations.summary }}{{ end }}
   
 message_template: |
+  {{ if .Annotations.description }}*Description:* {{ .Annotations.description }}{{ end }}
   :chart_with_upwards_trend: *<{{ .GeneratorURL }}|Graph>*
   {{- if .Annotations.alertman_url }} :bell: *<{{ .Annotations.alertman_url }}|Alerts>*{{ end }}
   {{- if .Annotations.runbook }} :notebook: *<{{ .Annotations.runbook }}|Runbook>*{{ end }}
-
-  *Alert:* {{ if .Annotations.title }}{{ .Annotations.title }}{{ end }}{{ if .Annotations.summary }}{{ .Annotations.summary }}{{ end }}
-  {{ if .Labels.severity }}*Severity:*  `{{ .Labels.severity }}`{{ end }}
-  {{ if .Annotations.message }}*Message:*  {{ .Annotations.message }}{{ end }}
-  {{ if .Annotations.description }}*Description:* {{ .Annotations.description }}{{ end }}
   *Details:*
     {{ range $key, $value := .Labels }} • {{ $key }}: {{ $value }}
     {{ end }}

--- a/config.bugsnag.yaml
+++ b/config.bugsnag.yaml
@@ -13,9 +13,6 @@ header_template: |
   *Status:* {{if eq .Status "firing" }}:fire: Firing{{else}}:white_check_mark: Resolved{{ end }}
   *Alert:* {{ if .Annotations.title }}{{ .Annotations.title }}{{ end }}{{ if .Annotations.summary }}{{ .Annotations.summary }}{{ end }}
   
-# footer_template: |
-#   {{if eq .Status "firing" }}:fire: Refired{{else}}:white_check_mark: Resolved{{ end }} {{ dateFormat "15:04:05" (now) "UTC" }}
-
 message_template: |
   :chart_with_upwards_trend: *<{{ .GeneratorURL }}|Graph>*
   {{- if .Annotations.alertman_url }} :bell: *<{{ .Annotations.alertman_url }}|Alerts>*{{ end }}

--- a/config.bugsnag.yaml
+++ b/config.bugsnag.yaml
@@ -10,7 +10,7 @@ metric_resolution: 100
 
 header_template: |
   *{{ .Labels.alertname }}*
-  *Status:* {{if eq .Status "firing" }}:fire:{{else}}:white_check_mark::{{ end }}
+  *Status:* {{if eq .Status "firing" }}:fire: Firing{{else}}:white_check_mark: Resolved{{ end }}
 
 footer_template: |
   {{if eq .Status "firing" }}:fire: Refired{{else}}:white_check_mark: Resolved{{ end }} {{ dateFormat "15:04:05" (now) "UTC" }}


### PR DESCRIPTION
There are some issues with Promalert threaded messages:
- The app would need to maintain a quorum to support this functionality as the cluster instances can't update each others messages - this leads to inconsistent alerts.
- It seems to mess with the timestamp of the original message which isn't useful
- There are limitations updating historic messages with different colour bars (could be linked to issue one)

The feature isn't really that useful anyways and we should avoid making the tiny app too complex as it is a fork and there are no tests.