### PR TITLE
[INFRA-1766] Promalert updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+SHELL := /bin/bash
+NAME=promalert
+HOST=gcr.io/bugsnag-155907
+VER=1.1.15
+IMAGE=$(HOST)/$(NAME):$(VER)
+
+.DEFAULT_GOAL := help
+.PHONY: test pipfile
+# Tasks
+test: ## Run unit tests
+	@echo "---> [Executing go tests]"
+	@go test . -race -timeout 30m -p 1
+
+image: ## Build image given VER
+	@echo "---> [Executing docker build]"
+	@docker build . -t $(IMAGE)
+	@docker push $(IMAGE)
+	@echo $(IMAGE)
+
+build: test image ## Creates a unit tested image
+	@echo "---> [All done!]"
+
+help: ## Print help for all functions of Makefile
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {sub("\\\\n",sprintf("\n%22c"," "), $$2);printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Environment variables prefix: `PROMALERT_`
 | `message_template`  | Slack message template. Go template syntax        | [`config.example.yaml`](config.example.yaml#L18) |
 | `header_template`   | Slack message header template. Go template syntax | [`config.example.yaml`](config.example.yaml#L11) |
 | `footer_template`   | Slack message footer template. Go template syntax | [`config.example.yaml`](config.example.yaml#L15) |
+| `graph_scale`       | Scale the graph image                             | `1.0`                                            |
 
 ### AWS
 AWS credentials parsed by [aws-go-client](https://github.com/aws/aws-sdk-go) in the following [order](https://github.com/aws/aws-sdk-go#configuring-credentials):

--- a/config.bugsnag.yaml
+++ b/config.bugsnag.yaml
@@ -15,10 +15,10 @@ header_template: |
   *Alert:* {{ if .Annotations.title }}{{ .Annotations.title }}{{ end }}{{ if .Annotations.summary }}{{ .Annotations.summary }}{{ end }}
   
 message_template: |
-  {{ if .Annotations.description }}*Description:* {{ .Annotations.description }}{{ end }}
-  :chart_with_upwards_trend: *<{{ .GeneratorURL }}|Graph>*
+  *Actions:* :chart_with_upwards_trend: *<{{ .GeneratorURL }}|Graph>*
   {{- if .Annotations.alertman_url }} :bell: *<{{ .Annotations.alertman_url }}|Alerts>*{{ end }}
   {{- if .Annotations.runbook }} :notebook: *<{{ .Annotations.runbook }}|Runbook>*{{ end }}
+  {{ if .Annotations.description }}*Description:* {{ .Annotations.description }}{{ end }}
   *Details:*
     {{ range $key, $value := .Labels }} • {{ $key }}: {{ $value }}
     {{ end }}

--- a/plotter.go
+++ b/plotter.go
@@ -23,7 +23,6 @@ import (
 
 // Only show important part of metric name
 var labelText = regexp.MustCompile("{(.*)}")
-var graphScale = viper.GetFloat("graph_scale", 1.0)
 
 func GetPlotExpr(alertFormula string) []PlotExpr {
 	expr, _ := promql.ParseExpr(alertFormula)
@@ -111,17 +110,20 @@ func Plot(expr PlotExpr, queryTime time.Time, duration, resolution time.Duration
 }
 
 func PlotMetric(metrics model.Matrix, level float64, direction string) (io.WriterTo, error) {
+	viper.SetDefault("graph_scale", 1.0)
+	var graphScale = viper.GetFloat64("graph_scale")
+
 	p, err := plot.New()
 	if err != nil {
 		return nil, fmt.Errorf("failed to create new plot: %v", err)
 	}
 
-	textFont, err := vg.MakeFont("Helvetica", (2.5*vg.Millimeter)*graphScale)
+	textFont, err := vg.MakeFont("Helvetica", vg.Length(2.5*graphScale)*vg.Millimeter)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load font: %v", err)
 	}
 
-	evalTextFont, err := vg.MakeFont("Helvetica", (3*vg.Millimeter)*graphScale)
+	evalTextFont, err := vg.MakeFont("Helvetica", vg.Length(3*graphScale)*vg.Millimeter)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load font: %v", err)
 	}
@@ -139,7 +141,7 @@ func PlotMetric(metrics model.Matrix, level float64, direction string) (io.Write
 	p.Y.Tick.Label.Font = textFont
 	p.Legend.Font = textFont
 	p.Legend.Top = true
-	p.Legend.YOffs = (15 * vg.Millimeter) * graphScale
+	p.Legend.YOffs = vg.Length(15*graphScale) * vg.Millimeter
 
 	// Color palette for drawing lines
 	paletteSize := 8
@@ -197,9 +199,9 @@ func PlotMetric(metrics model.Matrix, level float64, direction string) (io.Write
 	p.Add(plotter.NewGrid())
 
 	// Draw plot in canvas with margin
-	margin := (3 * vg.Millimeter) * graphScale
-	width := (12 * vg.Centimeter) * graphScale
-	height := (6 * vg.Centimeter) * graphScale
+	margin := vg.Length(3*graphScale) * vg.Millimeter
+	width := vg.Length(12*graphScale) * vg.Centimeter
+	height := vg.Length(6*graphScale) * vg.Centimeter
 	c, err := draw.NewFormattedCanvas(width, height, "png")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create canvas: %v", err)

--- a/plotter.go
+++ b/plotter.go
@@ -17,10 +17,13 @@ import (
 	"gonum.org/v1/plot/plotter"
 	"gonum.org/v1/plot/vg"
 	"gonum.org/v1/plot/vg/draw"
+
+	"github.com/spf13/viper"
 )
 
 // Only show important part of metric name
 var labelText = regexp.MustCompile("{(.*)}")
+var graphScale = viper.GetFloat("graph_scale", 1.0)
 
 func GetPlotExpr(alertFormula string) []PlotExpr {
 	expr, _ := promql.ParseExpr(alertFormula)
@@ -113,12 +116,12 @@ func PlotMetric(metrics model.Matrix, level float64, direction string) (io.Write
 		return nil, fmt.Errorf("failed to create new plot: %v", err)
 	}
 
-	textFont, err := vg.MakeFont("Helvetica", 2.5*vg.Millimeter)
+	textFont, err := vg.MakeFont("Helvetica", 2.5*vg.Millimeter*graphScale)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load font: %v", err)
 	}
 
-	evalTextFont, err := vg.MakeFont("Helvetica", 3*vg.Millimeter)
+	evalTextFont, err := vg.MakeFont("Helvetica", 3*vg.Millimeter*graphScale)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load font: %v", err)
 	}
@@ -136,7 +139,7 @@ func PlotMetric(metrics model.Matrix, level float64, direction string) (io.Write
 	p.Y.Tick.Label.Font = textFont
 	p.Legend.Font = textFont
 	p.Legend.Top = true
-	p.Legend.YOffs = 15 * vg.Millimeter
+	p.Legend.YOffs = 15 * vg.Millimeter * graphScale
 
 	// Color palette for drawing lines
 	paletteSize := 8
@@ -194,9 +197,9 @@ func PlotMetric(metrics model.Matrix, level float64, direction string) (io.Write
 	p.Add(plotter.NewGrid())
 
 	// Draw plot in canvas with margin
-	margin := 3 * vg.Millimeter
-	width := 12 * vg.Centimeter
-	height := 6 * vg.Centimeter
+	margin := 3 * vg.Millimeter * graphScale 
+	width := 12 * vg.Centimeter * graphScale
+	height := 6 * vg.Centimeter * graphScale
 	c, err := draw.NewFormattedCanvas(width, height, "png")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create canvas: %v", err)

--- a/plotter.go
+++ b/plotter.go
@@ -116,12 +116,12 @@ func PlotMetric(metrics model.Matrix, level float64, direction string) (io.Write
 		return nil, fmt.Errorf("failed to create new plot: %v", err)
 	}
 
-	textFont, err := vg.MakeFont("Helvetica", 2.5*vg.Millimeter*graphScale)
+	textFont, err := vg.MakeFont("Helvetica", (2.5*vg.Millimeter)*graphScale)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load font: %v", err)
 	}
 
-	evalTextFont, err := vg.MakeFont("Helvetica", 3*vg.Millimeter*graphScale)
+	evalTextFont, err := vg.MakeFont("Helvetica", (3*vg.Millimeter)*graphScale)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load font: %v", err)
 	}
@@ -139,7 +139,7 @@ func PlotMetric(metrics model.Matrix, level float64, direction string) (io.Write
 	p.Y.Tick.Label.Font = textFont
 	p.Legend.Font = textFont
 	p.Legend.Top = true
-	p.Legend.YOffs = 15 * vg.Millimeter * graphScale
+	p.Legend.YOffs = (15 * vg.Millimeter) * graphScale
 
 	// Color palette for drawing lines
 	paletteSize := 8
@@ -197,9 +197,9 @@ func PlotMetric(metrics model.Matrix, level float64, direction string) (io.Write
 	p.Add(plotter.NewGrid())
 
 	// Draw plot in canvas with margin
-	margin := 3 * vg.Millimeter * graphScale 
-	width := 12 * vg.Centimeter * graphScale
-	height := 6 * vg.Centimeter * graphScale
+	margin := (3 * vg.Millimeter) * graphScale
+	width := (12 * vg.Centimeter) * graphScale
+	height := (6 * vg.Centimeter) * graphScale
 	c, err := draw.NewFormattedCanvas(width, height, "png")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create canvas: %v", err)

--- a/slack.go
+++ b/slack.go
@@ -39,7 +39,6 @@ func ComposeResolveUpdateBody(alert Alert, headerTemplate string, images ...Slac
 
 	var blocks []slack.Block
 	blocks = append(blocks, slack.NewSectionBlock(statusBlock, nil, nil))
-	blocks = append(blocks, slack.NewDividerBlock())
 	for _, image := range images {
 		textBlock := slack.NewTextBlockObject("plain_text", image.Title, false, false)
 		blocks = append(blocks, slack.NewImageBlock(image.Url, "metric graph "+image.Title, "", textBlock))
@@ -61,7 +60,6 @@ func ComposeUpdateFooter(alert Alert, footerTemplate string) ([]slack.Block, err
 	)
 
 	var blocks []slack.Block
-	blocks = append(blocks, slack.NewDividerBlock())
 	blocks = append(blocks, slack.NewContextBlock("", footerBlock))
 
 	return blocks, nil
@@ -91,7 +89,6 @@ func ComposeMessageBody(alert Alert, messageTemplate, headerTemplate string, ima
 	)
 	var blocks []slack.Block
 	blocks = append(blocks, slack.NewSectionBlock(statusBlock, nil, nil))
-	blocks = append(blocks, slack.NewDividerBlock())
 	blocks = append(blocks, slack.NewSectionBlock(textBlockObj, nil, nil))
 	for _, image := range images {
 		textBlock := slack.NewTextBlockObject("plain_text", image.Title, false, false)


### PR DESCRIPTION
This update contains a number of fixes and tweaks:
- Adds a Makefile
- Add a `graph_scale` attribute to scale the charts in Slack (using an environment variable)
- Removes the separator
- Annotates the graph / alerts links and moves them to the top of the message body