### PR TITLE
More detailed error output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SHELL := /bin/bash
 NAME=promalert
 HOST=gcr.io/bugsnag-155907
-VER=1.2.9
+VER=1.2.10
 IMAGE=$(HOST)/$(NAME):$(VER)
 
 .DEFAULT_GOAL := help

--- a/plotter.go
+++ b/plotter.go
@@ -71,7 +71,7 @@ func Plot(expr PlotExpr, queryTime time.Time, duration, resolution time.Duration
 		resolution,
 	)
 	if err != nil {
-		_ = bugsnag.Notify(err, nil,
+		_ = bugsnag.Notify(errr
 			bugsnag.MetaData{
 				"Expression": {
 					"PrometheusUrl":      prometheusUrl,
@@ -120,7 +120,7 @@ func Plot(expr PlotExpr, queryTime time.Time, duration, resolution time.Duration
 	clog.Infof("Creating plot: %s", alert.Annotations["summary"])
 	plottedMetric, err := PlotMetric(selectedMetrics, expr.Level, expr.Operator)
 	if err != nil {
-		_ = bugsnag.Notify(err, nil,
+		_ = bugsnag.Notify(err,
 			bugsnag.MetaData{
 				"Expression": {
 					"PrometheusUrl":      prometheusUrl,

--- a/plotter.go
+++ b/plotter.go
@@ -71,7 +71,7 @@ func Plot(expr PlotExpr, queryTime time.Time, duration, resolution time.Duration
 		resolution,
 	)
 	if err != nil {
-		_ = bugsnag.Notify(errors.Wrap(err, "error querying Prometheus"), nil,
+		_ = bugsnag.Notify(err, nil,
 			bugsnag.MetaData{
 				"Expression": {
 					"PrometheusUrl":      prometheusUrl,
@@ -120,7 +120,7 @@ func Plot(expr PlotExpr, queryTime time.Time, duration, resolution time.Duration
 	clog.Infof("Creating plot: %s", alert.Annotations["summary"])
 	plottedMetric, err := PlotMetric(selectedMetrics, expr.Level, expr.Operator)
 	if err != nil {
-		_ = bugsnag.Notify(errors.Wrap(err, "error creating plot"), nil,
+		_ = bugsnag.Notify(err, nil,
 			bugsnag.MetaData{
 				"Expression": {
 					"PrometheusUrl":      prometheusUrl,

--- a/plotter.go
+++ b/plotter.go
@@ -18,7 +18,7 @@ import (
 	"gonum.org/v1/plot/vg"
 	"gonum.org/v1/plot/vg/draw"
 
-	"github.com/bugsnag/bugsnag-go"
+	"github.com/bugsnag/bugsnag-go/v2"
 	"github.com/bugsnag/microkit/clog"
 	"github.com/spf13/viper"
 )

--- a/plotter.go
+++ b/plotter.go
@@ -18,6 +18,7 @@ import (
 	"gonum.org/v1/plot/vg"
 	"gonum.org/v1/plot/vg/draw"
 
+	"github.com/bugsnag/bugsnag-go"
 	"github.com/bugsnag/microkit/clog"
 	"github.com/spf13/viper"
 )
@@ -70,6 +71,20 @@ func Plot(expr PlotExpr, queryTime time.Time, duration, resolution time.Duration
 		resolution,
 	)
 	if err != nil {
+		_ = bugsnag.Notify(errors.Wrap(err, "error querying Prometheus"), nil,
+			bugsnag.MetaData{
+				"Expression": {
+					"PrometheusUrl":      prometheusUrl,
+					"ExpressionFormula":  expr.Formula,
+					"ExpressionOperator": expr.Operator,
+					"QueryTime":          queryTime.String(),
+				},
+				"Alert": {
+					"GeneratorURL": alert.GeneratorURL,
+					"Channel":      alert.Channel,
+					"MessageTS":    alert.MessageTS,
+				},
+			})
 		return nil, err
 	}
 
@@ -104,6 +119,20 @@ func Plot(expr PlotExpr, queryTime time.Time, duration, resolution time.Duration
 	clog.Infof("Creating plot: %s", alert.Annotations["summary"])
 	plottedMetric, err := PlotMetric(selectedMetrics, expr.Level, expr.Operator)
 	if err != nil {
+		_ = bugsnag.Notify(errors.Wrap(err, "error creating plot"), nil,
+			bugsnag.MetaData{
+				"Expression": {
+					"PrometheusUrl":      prometheusUrl,
+					"ExpressionFormula":  expr.Formula,
+					"ExpressionOperator": expr.Operator,
+					"QueryTime":          queryTime.String(),
+				},
+				"Alert": {
+					"GeneratorURL": alert.GeneratorURL,
+					"Channel":      alert.Channel,
+					"MessageTS":    alert.MessageTS,
+				},
+			})
 		return nil, err
 	}
 

--- a/plotter.go
+++ b/plotter.go
@@ -80,6 +80,7 @@ func Plot(expr PlotExpr, queryTime time.Time, duration, resolution time.Duration
 					"QueryTime":          queryTime.String(),
 				},
 				"Alert": {
+					"Name":         alert.Labels["name"],
 					"GeneratorURL": alert.GeneratorURL,
 					"Channel":      alert.Channel,
 					"MessageTS":    alert.MessageTS,
@@ -128,6 +129,7 @@ func Plot(expr PlotExpr, queryTime time.Time, duration, resolution time.Duration
 					"QueryTime":          queryTime.String(),
 				},
 				"Alert": {
+					"Name":         alert.Labels["name"],
 					"GeneratorURL": alert.GeneratorURL,
 					"Channel":      alert.Channel,
 					"MessageTS":    alert.MessageTS,

--- a/plotter.go
+++ b/plotter.go
@@ -71,7 +71,7 @@ func Plot(expr PlotExpr, queryTime time.Time, duration, resolution time.Duration
 		resolution,
 	)
 	if err != nil {
-		_ = bugsnag.Notify(errr
+		_ = bugsnag.Notify(err,
 			bugsnag.MetaData{
 				"Expression": {
 					"PrometheusUrl":      prometheusUrl,


### PR DESCRIPTION
Extends the Bugsnag notify payload to include some stats that might be interesting in the issue involving handling of `+inf` values, also notifies Bugsnag sooner, which might permit full stacktraces (although I admittedly have no idea what's causing that issue right now)