### PR TITLE
Don't shorten URLs formatted as code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SHELL := /bin/bash
 NAME=promalert
 HOST=gcr.io/bugsnag-155907
-VER=1.2.13
+VER=1.2.14
 IMAGE=$(HOST)/$(NAME):$(VER)
 
 .DEFAULT_GOAL := help

--- a/kutt.go
+++ b/kutt.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"regexp"
 	"strings"
 	"time"
 
@@ -108,7 +109,9 @@ func (cli *Client) Submit(ctx context.Context, target string) (*LinkResponse, er
 }
 
 func (cli *Client) ReplaceLinks(ctx context.Context, target string) (error, string) {
-	r := xurls.Strict()
+	r := regexp.MustCompile("[^`]" + xurls.Strict().String() + "[^`]")
+	r.Longest()
+
 	raw := r.FindAllString(target, -1)
 	for _, r := range raw {
 		url, err := cli.Submit(ctx, r)


### PR DESCRIPTION
This will make the endpoint alerts nicer.