### PR TITLE
Revert "Don't shorten URLs formatted as code"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SHELL := /bin/bash
 NAME=promalert
 HOST=gcr.io/bugsnag-155907
-VER=1.2.14
+VER=1.2.13
 IMAGE=$(HOST)/$(NAME):$(VER)
 
 .DEFAULT_GOAL := help

--- a/kutt.go
+++ b/kutt.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
-	"regexp"
 	"strings"
 	"time"
 
@@ -109,9 +108,7 @@ func (cli *Client) Submit(ctx context.Context, target string) (*LinkResponse, er
 }
 
 func (cli *Client) ReplaceLinks(ctx context.Context, target string) (error, string) {
-	r := regexp.MustCompile("[^`]" + xurls.Strict().String() + "[^`]")
-	r.Longest()
-
+	r := xurls.Strict()
 	raw := r.FindAllString(target, -1)
 	for _, r := range raw {
 		url, err := cli.Submit(ctx, r)


### PR DESCRIPTION
Reverts bugsnag/promalert#29

This doesn't work for the annotations as they are the full string. I would do a look-behind/ahead but golang doesn't support them.

This would be an option:
```r := regexp.MustCompile("([^`]|^)" + xurls.Strict().String() + "([^`]|$)")```

But in further testing the fact that those capture makes things a bit awkward.

So backing this out for now.
